### PR TITLE
replace Chinese with Thai in hello.go

### DIFF
--- a/tour/content/welcome/hello.go
+++ b/tour/content/welcome/hello.go
@@ -5,5 +5,5 @@ package main
 import "fmt"
 
 func main() {
-	fmt.Println("Hello, 世界")
+	fmt.Println("Hello, สวัสดี")
 }


### PR DESCRIPTION
Currently `hello.go` in `tour/content/welcome` prints `"Hello, 世界"`.

For Thai page, it is supposed to be in Thai language.